### PR TITLE
Use c_char instead of i8 for callback

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -31,7 +31,7 @@ pub fn sixel_string(
     pixelformat: PixelFormat,
     method_for_diffuse: DiffusionMethod,
 ) -> Status<String> {
-    let mut sixel_data: Vec<i8> = Vec::new();
+    let mut sixel_data: Vec<::std::os::raw::c_char> = Vec::new();
     let sixel_data_ptr: *mut c_void = &mut sixel_data as *mut _ as *mut c_void;
 
     let mut output: *mut Output = ptr::null_mut() as *mut _;
@@ -47,9 +47,10 @@ pub fn sixel_string(
         size: ::std::os::raw::c_int,
         priv_: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int {
-        let sixel_data: &mut Vec<i8> = &mut *(priv_ as *mut Vec<i8>);
+        let sixel_data: &mut Vec<::std::os::raw::c_char> =
+            &mut *(priv_ as *mut Vec<::std::os::raw::c_char>);
 
-        let data_slice: &mut [i8] =
+        let data_slice: &mut [::std::os::raw::c_char] =
             slice::from_raw_parts_mut(if data.is_null() { return 1 } else { data }, size as usize);
         sixel_data.append(&mut data_slice.to_vec());
         sixel_status::OK


### PR DESCRIPTION
Same as sixel-bytes PR https://github.com/benjajaja/sixel-bytes/pull/3.

c_char is unsigned on platforms like aarch64 and riscv64. Forcing i8 results in a compile error at `slice::from_raw_parts_mut` [1].

Tested with presenterm [2] on both x86_64 and riscv64.

[1] https://github.com/benjajaja/sixel-bytes/blob/b41fda544a6ade744c9e6f98f1fa9ff876d048f4/src/lib.rs#L159
[2] https://gitlab.archlinux.org/archlinux/packaging/packages/presenterm/-/blob/main/PKGBUILD

If possible, please make a new release so we can incorporate the change into `presenterm` soon, so downstream maintainers like Arch Linux RISC-V won't need to maintain this patch for an extended period. :P